### PR TITLE
Implement CMake integration + bootstrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ compile_commands.json
 temp.*
 .vs
 .cache
+build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(cmkr PUBLIC
 install(
 	TARGETS cmkr 
 	DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+	COMPONENT cmkr
 	)
 
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,23 @@
+# This file was generated automatically by cmkr.
+
+# Regenerate CMakeLists.txt file when necessary
+include(cmkr.cmake OPTIONAL RESULT_VARIABLE CMKR_INCLUDE_RESULT)
+if(CMKR_INCLUDE_RESULT)
+	cmkr()
+endif()
+
+cmake_minimum_required(VERSION 3.15)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set(example_PROJECT_VERSION 0.1.0)
+project(example VERSION ${example_PROJECT_VERSION})
+
+set(EXAMPLE_SOURCES
+	"src/example.cpp"
+	)
+
+add_executable(example  ${EXAMPLE_SOURCES})
+
+
+

--- a/cmake/cmake.toml
+++ b/cmake/cmake.toml
@@ -1,0 +1,13 @@
+# This is a minimal example project used for testing the cmkr bootstrapping process
+
+[cmake]
+minimum = "3.15"
+
+[project]
+name = "example"
+version = "0.1.0"
+
+[[bin]]
+name = "example"
+type = "exe"
+sources = ["src/example.cpp"]

--- a/cmake/cmkr.cmake
+++ b/cmake/cmkr.cmake
@@ -1,0 +1,112 @@
+include_guard()
+
+# Disable cmkr if no cmake.toml file is found
+if(NOT EXISTS ${CMAKE_CURRENT_LIST_DIR}/cmake.toml)
+    message(STATUS "[cmkr] Not found: ${CMAKE_CURRENT_LIST_DIR}/cmake.toml")
+    macro(cmkr)
+    endmacro()
+    return()
+endif()
+
+# Add a build-time dependency on the contents of cmake.toml to regenerate the CMakeLists.txt when modified
+configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake.toml ${CMAKE_CURRENT_BINARY_DIR}/cmake.toml COPYONLY)
+
+# Helper macro to execute a process (COMMAND_ERROR_IS_FATAL ANY is 3.19 and higher)
+macro(cmkr_exec)
+    execute_process(COMMAND ${ARGV} RESULT_VARIABLE CMKR_EXEC_RESULT)
+    if(NOT CMKR_EXEC_RESULT EQUAL 0)
+        message(FATAL_ERROR "cmkr_exec(${ARGV}) failed (exit code ${CMKR_EXEC_RESULT})")
+    endif()
+endmacro()
+
+# Windows-specific hack (CMAKE_EXECUTABLE_PREFIX is not set at the moment)
+if(WIN32)
+    set(CMKR_EXECUTABLE_NAME "cmkr.exe")
+else()
+    set(CMKR_EXECUTABLE_NAME "cmkr")
+endif()
+
+# Use cached cmkr if found
+if(DEFINED CACHE{CMKR_EXECUTABLE} AND EXISTS ${CMKR_EXECUTABLE})
+    message(VERBOSE "[cmkr] Found cmkr: '${CMKR_EXECUTABLE}'")
+else()
+    if(DEFINED CACHE{CMKR_EXECUTABLE})
+        message(VERBOSE "[cmkr] '${CMKR_EXECUTABLE}' not found")
+    endif()
+    set(CMKR_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/_cmkr)
+    set(CMKR_EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/_cmkr/bin/${CMKR_EXECUTABLE_NAME} CACHE INTERNAL "Full path to cmkr executable")
+    if(NOT EXISTS ${CMKR_EXECUTABLE})
+        message(VERBOSE "[cmkr] Bootstrapping '${CMKR_EXECUTABLE}'")
+        message(STATUS "[cmkr] Fetching cmkr...")
+        if(EXISTS ${CMKR_DIRECTORY})
+            cmkr_exec(${CMAKE_COMMAND} -E rm -rf ${CMKR_DIRECTORY})
+        endif()
+        find_package(Git QUIET REQUIRED)
+        set(CMKR_REPO "https://github.com/mrexodia/cmkr")
+        cmkr_exec(${GIT_EXECUTABLE} clone ${CMKR_REPO} ${CMKR_DIRECTORY})
+        cmkr_exec(${CMAKE_COMMAND} ${CMKR_DIRECTORY} -B${CMKR_DIRECTORY}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${CMKR_DIRECTORY})
+        cmkr_exec(${CMAKE_COMMAND} --build ${CMKR_DIRECTORY}/build --parallel --config Release)
+        cmkr_exec(${CMAKE_COMMAND} --install ${CMKR_DIRECTORY}/build --config Release --prefix ${CMKR_DIRECTORY} --component cmkr)
+        if(NOT EXISTS ${CMKR_EXECUTABLE})
+            message(FATAL_ERROR "[cmkr] Failed to bootstrap '${CMKR_EXECUTABLE}'")
+        endif()
+        cmkr_exec(${CMKR_EXECUTABLE} version OUTPUT_VARIABLE CMKR_VERSION)
+        string(STRIP ${CMKR_VERSION} CMKR_VERSION)
+        message(STATUS "[cmkr] Bootstrapped ${CMKR_EXECUTABLE}")
+    else()
+        message(VERBOSE "[cmkr] Found cmkr: '${CMKR_EXECUTABLE}'")
+    endif()
+endif()
+execute_process(COMMAND ${CMKR_EXECUTABLE} version
+    OUTPUT_VARIABLE CMKR_VERSION
+    RESULT_VARIABLE CMKR_EXEC_RESULT
+)
+if(NOT CMKR_EXEC_RESULT EQUAL 0)
+    unset(CMKR_EXECUTABLE CACHE)
+    message(FATAL_ERROR "[cmkr] Failed to get version, try clearing the cache and rebuilding")
+endif()
+string(STRIP ${CMKR_VERSION} CMKR_VERSION)
+message(STATUS "[cmkr] Using ${CMKR_VERSION}")
+
+# This is the macro that contains black magic
+macro(cmkr)
+    # When this macro is called from the generated file, fake some internal CMake variables
+    get_source_file_property(CMKR_CURRENT_LIST_FILE ${CMAKE_CURRENT_LIST_FILE} CMKR_CURRENT_LIST_FILE)
+    if(CMKR_CURRENT_LIST_FILE)
+        set(CMAKE_CURRENT_LIST_FILE ${CMKR_CURRENT_LIST_FILE})
+        get_filename_component(CMAKE_CURRENT_LIST_DIR ${CMAKE_CURRENT_LIST_FILE} DIRECTORY)
+    endif()
+
+    # File-based include guard (include_guard is not documented to work)
+    get_source_file_property(CMKR_INCLUDE_GUARD ${CMAKE_CURRENT_LIST_FILE} CMKR_INCLUDE_GUARD)
+    if(NOT CMKR_INCLUDE_GUARD)
+        set_source_files_properties(${CMAKE_CURRENT_LIST_FILE} PROPERTIES CMKR_INCLUDE_GUARD TRUE)
+
+        # Generate CMakeLists.txt
+        cmkr_exec(${CMKR_EXECUTABLE} gen -y
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            OUTPUT_VARIABLE CMKR_GEN_OUTPUT
+        )
+        string(STRIP ${CMKR_GEN_OUTPUT} CMKR_GEN_OUTPUT)
+        message(STATUS "[cmkr] ${CMKR_GEN_OUTPUT}")
+
+        # Copy the now-generated CMakeLists.txt to CMakerLists.txt
+        # This is done because you cannot include() a file you are currently in
+        set(CMKR_TEMP_FILE ${CMAKE_CURRENT_LIST_DIR}/CMakerLists.txt)
+        configure_file(CMakeLists.txt ${CMKR_TEMP_FILE} COPYONLY)
+        
+        # Add the macro required for the hack at the start of the cmkr macro
+        set_source_files_properties(${CMKR_TEMP_FILE} PROPERTIES
+            CMKR_CURRENT_LIST_FILE ${CMAKE_CURRENT_LIST_FILE}
+        )
+        
+        # 'Execute' the newly-generated CMakeLists.txt
+        include(${CMKR_TEMP_FILE})
+        
+        # Delete the generated file
+        file(REMOVE ${CMKR_TEMP_FILE})
+        
+        # Do not execute the rest of the original CMakeLists.txt
+        return()
+    endif()
+endmacro()

--- a/cmake/src/example.cpp
+++ b/cmake/src/example.cpp
@@ -1,0 +1,6 @@
+#include <cstdio>
+
+int main()
+{
+    puts("Hello from cmkr!");
+}

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -109,7 +109,15 @@ int generate_cmake(const char *path) {
     if (fs::exists(fs::path(path) / "cmake.toml")) {
         cmake::CMake cmake(path, false);
         std::stringstream ss;
-        ss << "# This file was generated automatically by cmkr.\n\n";
+        ss << "# This file was generated automatically by cmkr.\n";
+        ss << "\n";
+        
+        ss << "# Regenerate CMakeLists.txt file when necessary\n";
+        ss << "include(cmkr.cmake OPTIONAL RESULT_VARIABLE CMKR_INCLUDE_RESULT)\n";
+        ss << "if(CMKR_INCLUDE_RESULT)\n";
+        ss << "\tcmkr()\n";
+        ss << "endif()\n";
+        ss << "\n";
 
         if (!cmake.cmake_version.empty()) {
             ss << "cmake_minimum_required(VERSION " << cmake.cmake_version << ")\n\n";


### PR DESCRIPTION
This is an initial version that implements some kind of self-hosting of cmkr from within cmake. The idea is that doing:

```
mkdir build && cd build
cmake ..
```

Will automatically build `cmkr` and regenerate `CMakeLists.txt` whenever you run cmake _or_ when you update `cmake.toml`.

I tested on Windows 10 with Visual Studio 2019 and WSL2 with Ubuntu 20.04 and it works super well!

The bootstrapper is optional and will only be used if you have `cmkr.cmake` next to `CMakeLists.txt`. Likely `cmkr gen` has to be updated to automatically generate this file (with an option), but that can be done easily.

## Design considerations

I explicitly designed this integration in such a way that it will **not** search the user's PATH, but instead always rebuild the top-level `cmkr` from scratch (all sub projects will use the version built by the root project). This is done because you can then pin to a specific `cmkr` version if you want and otherwise it will always use the latest version. You could change this, but then you have the issue that a package manager's `cmkr` version can basically be anything and users will run into compatibility issues later.

To override the `cmkr.exe` (only really useful for development purposes) use `-DCMKR_EXECUTABLE=/path/to/cmkr`.

The main downside is that whatever compiler cmake selects without specifying it currently has to support `std::filesystem` (most linux distributions do not have this (you have to do `CC=gcc-10 CXX=g++-10 cmake ..`).

The fix would be to have `cmkr` depend on the lowest c++ standard and cmake version as humanly possible, to allow a seamless bootstrapping process. Another idea is to rewrite cmkr in cmake itself, but I understand why you wouldn't want to do this. I did a quick check and it should be quite easy to switch to https://github.com/gulrak/filesystem to go down to c++11.

Additionally cross compiling is probably not working at all, but I don't use it so I didn't care. LLVM supports this for `llvm-tblgen` and you can look at that if you really want cross-compilation support (you have to somehow make CMake select a valid host compiler for that). Likely if somebody does `-DCMAKE_C_COMPILER=xxx -DCMAKE_CXX_COMPILER=yyy` (eg not use the `CC` and `CXX` environment variables) it will work but it's not a supported scenario right now.

Another downside is that because you cannot `include()` a file that you are currently already in (cmake bug?) I temporarily generate `CMakerLists.txt` next to `CMakeLists.txt`, which is then included and some hacks are done to hide this from the user. I'm not entirely sure if this is safe, but because cmkr is generating the CMakeLists.txt in question it should be fine.

Previously I was using `configure_file` to generate a `CMakeLists.txt` in the `CMAKE_CURRENT_BINARY_DIR`, but this could interfere with subprojects that also use `cmkr` so I decided to generate a temporary file in the source directory instead.

A fix would be to instead generate `CmkrGenerated.cmake`, move all the bootstrapping code to `CMakeLists.txt`, which then does `include(CMkrGenerated.cmake)`. That way you can overwrite that file before cmake 'sees' it and make it work without the terrible hacks. You could then even add `CMkrGenerate.cmake` to the `.gitignore` and have just a static `CMakeLists.txt` + `cmake.toml` checked out.